### PR TITLE
Handle disconnect during final ACK

### DIFF
--- a/chunked_ble_protocol.py
+++ b/chunked_ble_protocol.py
@@ -471,8 +471,14 @@ class ChunkedBLEProtocol:
             True if sent successfully, False otherwise
         """
         try:
-            if not self._control_characteristic:
-                self._log("[ERROR] Control characteristic not initialized")
+            if (
+                not self._control_characteristic
+                or not self.client
+                or not self.client.is_connected
+                or not self._control_notifications_enabled
+            ):
+                # Connection already cleaned up - ignore
+                self._log("[WARN] Cannot send ACK, client not connected")
                 return False
             
             # Create ACK message: ack_type(1) + chunk_number(4) + total_chunks(4) + global_crc32(4)


### PR DESCRIPTION
## Summary
- avoid errors when trying to send an ACK after the BLE connection is closed

## Testing
- `python3 -m py_compile chunked_ble_protocol.py simple_ble_client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685309959b7c8326bb2eac9dfec638d4